### PR TITLE
add github action to publish togithub node package registry

### DIFF
--- a/.github/workflows/publish-npm-github-registry.yml
+++ b/.github/workflows/publish-npm-github-registry.yml
@@ -1,0 +1,25 @@
+# source: https://docs.github.com/en/actions/guides/publishing-nodejs-packages
+name: Node.js Package
+on:
+  release:
+    types: [created]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v2
+      # Setup .npmrc file to publish to GitHub Packages
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '12.x'
+          registry-url: 'https://npm.pkg.github.com'
+          # Defaults to the user or organization that owns the workflow file
+          scope: '@w3f-webops'
+      - run: cd gatsby-theme-w3f
+      - run: yarn
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/gatsby-theme-w3f/package.json
+++ b/gatsby-theme-w3f/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@w3f-webops/gatsby-theme-w3f",
+  "name": "gatsby-theme-w3f",
   "private": false,
   "description": "w3f gatsby theme",
   "version": "0.0.1",

--- a/gatsby-theme-w3f/package.json
+++ b/gatsby-theme-w3f/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "gatsby-theme-w3f",
-  "private": true,
+  "name": "@w3f-webops/gatsby-theme-w3f",
+  "private": false,
   "description": "w3f gatsby theme",
   "version": "0.0.1",
   "author": "W3F <webops@web3.foundation>",


### PR DESCRIPTION
-> a github action, to publish the content of `./gatsby-theme-w3f` to the github's organisation package registry

This way we can install the theme as a npm module