### PR TITLE
fix sourcing of files when in site (vs in theme) /{content,media,locales}

### DIFF
--- a/gatsby-theme-w3f/gatsby-config.js
+++ b/gatsby-theme-w3f/gatsby-config.js
@@ -1,3 +1,6 @@
+/* to resolve "site" paths (vs. theme paths) */
+require('path')
+
 /* read the `.env.*` files, gatsby builtin */
 require('dotenv').config({
   path: `.env.${process.env.NODE_ENV}`,
@@ -79,7 +82,7 @@ module.exports = ({
       resolve: `gatsby-source-filesystem`,
       options: {
         name: `media`,
-        path: `${__dirname}/media`,
+        path: path.resolve('media'),
       },
     },
 
@@ -120,7 +123,7 @@ module.exports = ({
       resolve: `gatsby-source-filesystem`,
       options: {
         name: `content`,
-        path: `./content/`,
+        path: path.resolve('content'),
       },
     },
 
@@ -128,7 +131,7 @@ module.exports = ({
     {
       resolve: `gatsby-source-filesystem`,
       options: {
-        path: `${__dirname}/locales`,
+        path: path.resolve('locales'),
         name: `locale`,
       },
     },

--- a/gatsby-theme-w3f/src/hooks/use-site-menus.js
+++ b/gatsby-theme-w3f/src/hooks/use-site-menus.js
@@ -22,11 +22,11 @@ export const useSiteMenus = () => {
               id
               url
             }
-            legal {
+            network {
               id
               url
             }
-            extra {
+            community {
               id
               url
             }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2351,30 +2351,6 @@
     "@typescript-eslint/types" "4.29.1"
     eslint-visitor-keys "^2.0.0"
 
-"@w3f/gatsby-theme-w3f@^0.0.1":
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/@w3f/gatsby-theme-w3f/-/gatsby-theme-w3f-0.0.1.tgz#ee89db797eb5703b3eb8eb8c907f1dc061a0dc3d"
-  integrity sha512-0vOwNVW9zgHNoPGZraTfb562MTKYhAF/MRLveBqbL5HTFgvA1Zbw6+FDPOjpTRWfqmzAsYrE5OcM76VTD0Lw+g==
-  dependencies:
-    gatsby-plugin-image "^1.2.0"
-    gatsby-plugin-manifest "^3.2.0"
-    gatsby-plugin-netlify-cms "^5.8.0"
-    gatsby-plugin-offline "^4.2.0"
-    gatsby-plugin-react-helmet "^4.2.0"
-    gatsby-plugin-react-i18next "^1.1.1"
-    gatsby-plugin-react-svg "^3.0.1"
-    gatsby-plugin-sharp "^3.10.2"
-    gatsby-remark-images "^5.7.0"
-    gatsby-remark-relative-images "^2.0.2"
-    gatsby-source-filesystem "^3.2.0"
-    gatsby-transformer-remark "^3.1.0"
-    gatsby-transformer-sharp "^3.2.0"
-    i18next "^20.2.4"
-    netlify-cms-app "^2.15.20"
-    prop-types "^15.7.2"
-    react-helmet "^6.1.0"
-    react-i18next "^11.8.15"
-
 "@webassemblyjs/ast@1.11.1":
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.11.1.tgz#2bfd767eae1a6996f432ff7e8d7fc75679c0b6a7"
@@ -6828,6 +6804,30 @@ gatsby-telemetry@^2.11.0:
     lodash "^4.17.21"
     node-fetch "^2.6.1"
     uuid "3.4.0"
+
+gatsby-theme-w3f@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/gatsby-theme-w3f/-/gatsby-theme-w3f-0.0.1.tgz#83063d702ba1a74c8b8dc9bc27c04db461d1c10f"
+  integrity sha512-szhyW2hvUuZZUYo9dacA+j1i3Hx4uQRzy+oFPq2j8B+EmlR0L026rhIfhHFNghvOvlKsRCrHmV3dzUiUMy11EA==
+  dependencies:
+    gatsby-plugin-image "^1.2.0"
+    gatsby-plugin-manifest "^3.2.0"
+    gatsby-plugin-netlify-cms "^5.8.0"
+    gatsby-plugin-offline "^4.2.0"
+    gatsby-plugin-react-helmet "^4.2.0"
+    gatsby-plugin-react-i18next "^1.1.1"
+    gatsby-plugin-react-svg "^3.0.1"
+    gatsby-plugin-sharp "^3.10.2"
+    gatsby-remark-images "^5.7.0"
+    gatsby-remark-relative-images "^2.0.2"
+    gatsby-source-filesystem "^3.2.0"
+    gatsby-transformer-remark "^3.1.0"
+    gatsby-transformer-sharp "^3.2.0"
+    i18next "^20.2.4"
+    netlify-cms-app "^2.15.20"
+    prop-types "^15.7.2"
+    react-helmet "^6.1.0"
+    react-i18next "^11.8.15"
 
 gatsby-transformer-remark@^3.1.0:
   version "3.2.0"


### PR DESCRIPTION
use `require('path').resolve('content')`, to fix importing data queryable through the graphql interface, when on the site or in the theme