### PR TITLE
gatsbyTransformerRemarkInclude as theme option

### DIFF
--- a/gatsby-theme-w3f/README.md
+++ b/gatsby-theme-w3f/README.md
@@ -18,7 +18,8 @@ plugins: [
 	{
 		resolve: `@w3f/gatsby-theme-w3f`,
 		options: {
-			i18nLanguages: ['en', 'fr']
+			i18nLanguages: ['en', 'fr'],
+			gatsbyTransformerRemarkInclude: ['featured_image', 'markdownremark', 'image'],
 		}
 	},
 ]

--- a/gatsby-theme-w3f/gatsby-config.js
+++ b/gatsby-theme-w3f/gatsby-config.js
@@ -10,6 +10,7 @@ module.exports = ({
   /* theme options, passed from the project it is imported in */
   i18nLanguages = ['en'],
   siteUrl = 'https://example.com/',
+  gatsbyTransformerRemarkInclude: ['featured_image', 'markdownremark', 'image'],
 }) => ({
   siteMetadata: {
     title: `Gatsby theme`,
@@ -119,7 +120,7 @@ module.exports = ({
             options: {
               /* `/media/` already in img.src */
               staticFolderName: path.resolve('./content'),
-              include: ['featured_image', 'markdownremark', 'image'],
+              include: gatsbyTransformerRemarkInclude,
             },
           },
           // gatsby-remark-relative-images must go before gatsby-remark-images

--- a/gatsby-theme-w3f/package.json
+++ b/gatsby-theme-w3f/package.json
@@ -2,7 +2,7 @@
   "name": "@w3f/gatsby-theme-w3f",
   "private": false,
   "description": "w3f gatsby theme",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "author": "W3F <webops@web3.foundation>",
   "keywords": [
     "gatsby"


### PR DESCRIPTION
add a new theme option for gatsby-transformer-remark plugin, so theme user can customize the "attributes" of a model that can be used as (gatsby) image path in the models.